### PR TITLE
Added 'accesskey' for faster filtering

### DIFF
--- a/FasterTablesFilter.php
+++ b/FasterTablesFilter.php
@@ -12,7 +12,7 @@ class FasterTablesFilter {
 
 	function tablesPrint($tables) { ?>
 
-  <p class="jsonly"><input id="filter-field">
+  <p class="jsonly"><input id="filter-field" accesskey="r">
   <style>
     .select-text {
       margin-right: 5px;


### PR DESCRIPTION
This add browser's 'accesskey', so that i.e. in Chrome/Linux I can access the search field by pressing ALT+r
